### PR TITLE
Added support SPI v1 HAL driver

### DIFF
--- a/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415cx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415cx.h
@@ -4512,9 +4512,9 @@ typedef struct
 /*!< MDIV configuration */
 #define SPI_CTRL1_MDIV_Msk                  ((SPI_CTRL2_MDIV) | (0x7U << 3)         /*!< 0x00000138 */
 #define SPI_CTRL1_MDIV                      SPI_CTRL1_MDIV_Msk                      /*!< MDIV[3:0] bits (Master clock frequency division) */
-#define SPI_CTRL1_MDIV_0                    (0x1U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000008 */
-#define SPI_CTRL1_MDIV_1                    (0x2U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000010 */
-#define SPI_CTRL1_MDIV_2                    (0x4U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000020 */
+#define SPI_CTRL1_MDIV_0                    (0x1U << 3)                             /*!< 0x00000008 */
+#define SPI_CTRL1_MDIV_1                    (0x2U << 3)                             /*!< 0x00000010 */
+#define SPI_CTRL1_MDIV_2                    (0x4U << 3)                             /*!< 0x00000020 */
 #define SPI_CTRL1_MDIV_3                    SPI_CTRL2_MDIV                          /*!< 0x00000100 */
 
 #define SPI_CTRL1_SPIEN_Pos                 (6U)

--- a/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415kx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415kx.h
@@ -4471,9 +4471,9 @@ typedef struct
 /*!< MDIV configuration */
 #define SPI_CTRL1_MDIV_Msk                  ((SPI_CTRL2_MDIV) | (0x7U << 3)         /*!< 0x00000138 */
 #define SPI_CTRL1_MDIV                      SPI_CTRL1_MDIV_Msk                      /*!< MDIV[3:0] bits (Master clock frequency division) */
-#define SPI_CTRL1_MDIV_0                    (0x1U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000008 */
-#define SPI_CTRL1_MDIV_1                    (0x2U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000010 */
-#define SPI_CTRL1_MDIV_2                    (0x4U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000020 */
+#define SPI_CTRL1_MDIV_0                    (0x1U << 3)                             /*!< 0x00000008 */
+#define SPI_CTRL1_MDIV_1                    (0x2U << 3)                             /*!< 0x00000010 */
+#define SPI_CTRL1_MDIV_2                    (0x4U << 3)                             /*!< 0x00000020 */
 #define SPI_CTRL1_MDIV_3                    SPI_CTRL2_MDIV                          /*!< 0x00000100 */
 
 #define SPI_CTRL1_SPIEN_Pos                 (6U)

--- a/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415rx.h
+++ b/os/common/ext/CMSIS/ArteryTek/AT32F41x/at32f415rx.h
@@ -4539,9 +4539,9 @@ typedef struct
 /*!< MDIV configuration */
 #define SPI_CTRL1_MDIV_Msk                  ((SPI_CTRL2_MDIV) | (0x7U << 3)         /*!< 0x00000138 */
 #define SPI_CTRL1_MDIV                      SPI_CTRL1_MDIV_Msk                      /*!< MDIV[3:0] bits (Master clock frequency division) */
-#define SPI_CTRL1_MDIV_0                    (0x1U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000008 */
-#define SPI_CTRL1_MDIV_1                    (0x2U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000010 */
-#define SPI_CTRL1_MDIV_2                    (0x4U << SPI_CTRL1_MDIV_Pos)            /*!< 0x00000020 */
+#define SPI_CTRL1_MDIV_0                    (0x1U << 3)                             /*!< 0x00000008 */
+#define SPI_CTRL1_MDIV_1                    (0x2U << 3)                             /*!< 0x00000010 */
+#define SPI_CTRL1_MDIV_2                    (0x4U << 3)                             /*!< 0x00000020 */
 #define SPI_CTRL1_MDIV_3                    SPI_CTRL2_MDIV                          /*!< 0x00000100 */
 
 #define SPI_CTRL1_SPIEN_Pos                 (6U)

--- a/os/hal/ports/AT32/AT32F41x/hal_lld.h
+++ b/os/hal/ports/AT32/AT32F41x/hal_lld.h
@@ -51,7 +51,7 @@
 /**
  * @brief   Requires use of SPIv2 driver model.
  */
-#define HAL_LLD_SELECT_SPI_V2           FALSE
+#define HAL_LLD_SELECT_SPI_V2           TRUE
 
 /**
  * @name    Platform identification

--- a/os/hal/ports/AT32/AT32F41x/platform.mk
+++ b/os/hal/ports/AT32/AT32F41x/platform.mk
@@ -27,6 +27,7 @@ endif
 include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/DMAv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/GPIOv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/OTGv1/driver.mk
+include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/SPIv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/SYSTICKv1/driver.mk
 include $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/TMRv1/driver.mk
 

--- a/os/hal/ports/AT32/LLD/SPIv1/driver.mk
+++ b/os/hal/ports/AT32/LLD/SPIv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_SPI TRUE,$(HALCONF)),)
+PLATFORMSRC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
+endif
+else
+PLATFORMSRC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
+endif
+
+PLATFORMINC_CONTRIB += $(CHIBIOS_CONTRIB)/os/hal/ports/AT32/LLD/SPIv1

--- a/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
+++ b/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
@@ -1,0 +1,609 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2023 HorrorTroll
+    ChibiOS - Copyright (C) 2023 Zhaqian
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    SPIv1/hal_spi_v2_lld.c
+ * @brief   AT32 SPI (v2) subsystem low level driver source.
+ *
+ * @addtogroup SPI
+ * @{
+ */
+
+#include "hal.h"
+
+#if HAL_USE_SPI || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/** @brief SPI1 driver identifier.*/
+#if AT32_SPI_USE_SPI1 || defined(__DOXYGEN__)
+SPIDriver SPID1;
+#endif
+
+/** @brief SPI2 driver identifier.*/
+#if AT32_SPI_USE_SPI2 || defined(__DOXYGEN__)
+SPIDriver SPID2;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static void spi_lld_configure(SPIDriver *spip) {
+  uint32_t ctrl1, ctrl2;
+
+  /* Disabling SPI during (re)configuration.*/
+  spip->spi->CTRL1 = 0U;
+
+  /* Common CTRL1 and CTRL2 options.*/
+  ctrl1 = spip->config->ctrl1 & ~(SPI_CTRL1_MSTEN | SPI_CTRL1_SPIEN);
+  ctrl2 = spip->config->ctrl2 | SPI_CTRL2_DMAREN | SPI_CTRL2_DMATEN;
+
+  /* SPI setup.*/
+  if (spip->config->slave == false) {
+    ctrl1 |= SPI_CTRL1_SWCSEN | SPI_CTRL1_SWCSIL | SPI_CTRL1_MSTEN;
+    ctrl2 |= SPI_CTRL2_HWCSOE;
+  }
+
+  /* New configuration.*/
+  spip->spi->CTRL2 = ctrl2;
+  spip->spi->CTRL1 = ctrl1;
+  spip->spi->CTRL1 = ctrl1 | SPI_CTRL1_SPIEN;
+}
+
+/**
+ * @brief   Stopping the SPI transaction.
+ * @note    This is done nicely or by brutally resetting it depending on
+ *          the mode and settings.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ */
+static msg_t spi_lld_stop_abort(SPIDriver *spip) {
+
+  if (!spip->config->slave) {
+    /* Master mode, stopping gracefully.*/
+
+    /* Stopping TX DMA channel.*/
+    dmaStreamDisable(spip->dmatx);
+
+    /* Waiting for current frame completion then stop SPI.*/
+    while ((spip->spi->STS & SPI_STS_BF) != 0U) {
+    }
+
+    /* Now it is idle, stopping RX DMA channel.*/
+    dmaStreamDisable(spip->dmarx);
+  }
+  else {
+    /* Slave mode, this will not be nice.*/
+
+    /* Stopping DMAs.*/
+    dmaStreamDisable(spip->dmatx);
+    dmaStreamDisable(spip->dmarx);
+
+    /* Resetting SPI, this will stop it for sure and leave it
+       in a clean state.*/
+    if (false) {
+    }
+
+#if AT32_SPI_USE_SPI1
+    else if (&SPID1 == spip) {
+      crmResetSPI1();
+    }
+#endif
+
+#if AT32_SPI_USE_SPI2
+    else if (&SPID2 == spip) {
+      crmResetSPI2();
+    }
+#endif
+
+    else {
+      osalDbgAssert(false, "invalid SPI instance");
+    }
+
+    /* Reconfiguring SPI.*/
+    spi_lld_configure(spip);
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Shared end-of-rx service routine.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] flags     pre-shifted content of the STS register
+ */
+static void spi_lld_serve_rx_interrupt(SPIDriver *spip, uint32_t flags) {
+
+  /* DMA errors handling.*/
+  if ((flags & AT32_DMA_STS_DTERRF) != 0) {
+#if defined(AT32_SPI_DMA_ERROR_HOOK)
+    /* Hook first, if defined.*/
+    AT32_SPI_DMA_ERROR_HOOK(spip);
+#endif
+
+    /* Aborting the transfer.*/
+    (void) spi_lld_stop_abort(spip);
+
+    /* Reporting the failure.*/
+    __spi_isr_error_code(spip, HAL_RET_HW_FAILURE);
+  }
+  else if (spip->config->circular) {
+    if ((flags & AT32_DMA_STS_HDTF) != 0U) {
+      /* Half buffer interrupt.*/
+      __spi_isr_half_code(spip);
+    }
+    if ((flags & AT32_DMA_STS_FDTF) != 0U) {
+      /* End buffer interrupt.*/
+      __spi_isr_full_code(spip);
+    }
+  }
+  else {
+    /* Stopping the transfer.*/
+    (void) spi_lld_stop_abort(spip);
+
+    /* Operation finished interrupt.*/
+    __spi_isr_complete_code(spip);
+  }
+}
+
+/**
+ * @brief   Shared end-of-tx service routine.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] flags     pre-shifted content of the STS register
+ */
+static void spi_lld_serve_tx_interrupt(SPIDriver *spip, uint32_t flags) {
+
+  /* DMA errors handling.*/
+  if ((flags & AT32_DMA_STS_DTERRF) != 0) {
+#if defined(AT32_SPI_DMA_ERROR_HOOK)
+    /* Hook first, if defined.*/
+    AT32_SPI_DMA_ERROR_HOOK(spip);
+#endif
+
+    /* Aborting the transfer.*/
+    (void) spi_lld_stop_abort(spip);
+
+    /* Reporting the failure.*/
+    __spi_isr_error_code(spip, HAL_RET_HW_FAILURE);
+  }
+}
+
+/**
+ * @brief   DMA streams allocation.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] rxstream  stream to be allocated for RX
+ * @param[in] txstream  stream to be allocated for TX
+ * @param[in] priority  streams IRQ priority
+ * @return              The operation status.
+ */
+static msg_t spi_lld_get_dma(SPIDriver *spip, uint32_t rxstream,
+                             uint32_t txstream, uint32_t priority) {
+
+  spip->dmarx = dmaStreamAllocI(rxstream, priority,
+                                (at32_dmasts_t)spi_lld_serve_rx_interrupt,
+                                (void *)spip);
+  if (spip->dmarx == NULL) {
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  spip->dmatx = dmaStreamAllocI(txstream, priority,
+                                (at32_dmasts_t)spi_lld_serve_tx_interrupt,
+                                (void *)spip);
+  if (spip->dmatx == NULL) {
+    dmaStreamFreeI(spip->dmarx);
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level SPI driver initialization.
+ *
+ * @notapi
+ */
+void spi_lld_init(void) {
+
+#if AT32_SPI_USE_SPI1
+  spiObjectInit(&SPID1);
+  SPID1.spi       = SPI1;
+  SPID1.dmarx     = NULL;
+  SPID1.dmatx     = NULL;
+  SPID1.rxdmamode = AT32_DMA_CCTRL_CHPL(AT32_SPI_SPI1_DMA_PRIORITY) |
+                    AT32_DMA_CCTRL_DTD_P2M |
+                    AT32_DMA_CCTRL_FDTIEN |
+                    AT32_DMA_CCTRL_DTERRIEN;
+  SPID1.txdmamode = AT32_DMA_CCTRL_CHPL(AT32_SPI_SPI1_DMA_PRIORITY) |
+                    AT32_DMA_CCTRL_DTD_M2P |
+                    AT32_DMA_CCTRL_DTERRIEN;
+#endif
+
+#if AT32_SPI_USE_SPI2
+  spiObjectInit(&SPID2);
+  SPID2.spi       = SPI2;
+  SPID2.dmarx     = NULL;
+  SPID2.dmatx     = NULL;
+  SPID2.rxdmamode = AT32_DMA_CCTRL_CHPL(AT32_SPI_SPI2_DMA_PRIORITY) |
+                    AT32_DMA_CCTRL_DTD_P2M |
+                    AT32_DMA_CCTRL_FDTIEN |
+                    AT32_DMA_CCTRL_DTERRIEN;
+  SPID2.txdmamode = AT32_DMA_CCTRL_CHPL(AT32_SPI_SPI2_DMA_PRIORITY) |
+                    AT32_DMA_CCTRL_DTD_M2P |
+                    AT32_DMA_CCTRL_DTERRIEN;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the SPI peripheral.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_start(SPIDriver *spip) {
+  msg_t msg;
+
+  /* Resetting TX pattern source.*/
+  spip->txsource = (uint32_t)AT32_SPI_FILLER_PATTERN;
+
+  /* If in stopped state then enables the SPI and DMA clocks.*/
+  if (spip->state == SPI_STOP) {
+    if (false) {
+    }
+
+#if AT32_SPI_USE_SPI1
+    else if (&SPID1 == spip) {
+      msg = spi_lld_get_dma(spip,
+                            AT32_SPI_SPI1_RX_DMA_STREAM,
+                            AT32_SPI_SPI1_TX_DMA_STREAM,
+                            AT32_SPI_SPI1_IRQ_PRIORITY);
+      if (msg != HAL_RET_SUCCESS) {
+        return msg;
+      }
+      crmEnableSPI1(true);
+      crmResetSPI1();
+    }
+#endif
+
+#if AT32_SPI_USE_SPI2
+    else if (&SPID2 == spip) {
+      msg = spi_lld_get_dma(spip,
+                            AT32_SPI_SPI2_RX_DMA_STREAM,
+                            AT32_SPI_SPI2_TX_DMA_STREAM,
+                            AT32_SPI_SPI2_IRQ_PRIORITY);
+      if (msg != HAL_RET_SUCCESS) {
+        return msg;
+      }
+      crmEnableSPI2(true);
+      crmResetSPI2();
+    }
+#endif
+
+    else {
+      osalDbgAssert(false, "invalid SPI instance");
+    }
+
+    /* DMA setup.*/
+    dmaStreamSetPeripheral(spip->dmarx, &spip->spi->DT);
+    dmaStreamSetPeripheral(spip->dmatx, &spip->spi->DT);
+  }
+
+  /* Configuration-specific DMA setup.*/
+  if ((spip->config->ctrl1 & SPI_CTRL1_FBN) == 0) {
+    /* Frame width is 8 bits or smaller.*/
+    spip->rxdmamode = (spip->rxdmamode & ~AT32_DMA_CCTRL_SIZE_MASK) |
+                      AT32_DMA_CCTRL_PWIDTH_BYTE | AT32_DMA_CCTRL_MWIDTH_BYTE;
+    spip->txdmamode = (spip->txdmamode & ~AT32_DMA_CCTRL_SIZE_MASK) |
+                      AT32_DMA_CCTRL_PWIDTH_BYTE | AT32_DMA_CCTRL_MWIDTH_BYTE;
+  }
+  else {
+    /* Frame width is larger than 8 bits.*/
+    spip->rxdmamode = (spip->rxdmamode & ~AT32_DMA_CCTRL_SIZE_MASK) |
+                      AT32_DMA_CCTRL_PWIDTH_HWORD | AT32_DMA_CCTRL_MWIDTH_HWORD;
+    spip->txdmamode = (spip->txdmamode & ~AT32_DMA_CCTRL_SIZE_MASK) |
+                      AT32_DMA_CCTRL_PWIDTH_HWORD | AT32_DMA_CCTRL_MWIDTH_HWORD;
+  }
+
+  if (spip->config->circular) {
+    spip->rxdmamode |= (AT32_DMA_CCTRL_LM | AT32_DMA_CCTRL_HDTIEN);
+    spip->txdmamode |= (AT32_DMA_CCTRL_LM | AT32_DMA_CCTRL_HDTIEN);
+  }
+  else {
+    spip->rxdmamode &= ~(AT32_DMA_CCTRL_LM | AT32_DMA_CCTRL_HDTIEN);
+    spip->txdmamode &= ~(AT32_DMA_CCTRL_LM | AT32_DMA_CCTRL_HDTIEN);
+  }
+
+  /* SPI setup.*/
+  spi_lld_configure(spip);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the SPI peripheral.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+void spi_lld_stop(SPIDriver *spip) {
+
+  /* If in ready state then disables the SPI clock.*/
+  if (spip->state == SPI_READY) {
+
+    /* Just in case this has been called uncleanly.*/
+    (void) spi_lld_stop_abort(spip);
+
+    /* SPI cleanup.*/
+    spip->spi->CTRL1 = 0;
+    spip->spi->CTRL2 = 0;
+
+    /* DMA channels release.*/
+    dmaStreamFreeI(spip->dmatx);
+    dmaStreamFreeI(spip->dmarx);
+    spip->dmarx = NULL;
+    spip->dmatx = NULL;
+
+    /* Clock shutdown.*/
+    if (false) {
+    }
+
+#if AT32_SPI_USE_SPI1
+    else if (&SPID1 == spip) {
+      crmDisableSPI1();
+    }
+#endif
+
+#if AT32_SPI_USE_SPI2
+    else if (&SPID2 == spip) {
+      crmDisableSPI2();
+    }
+#endif
+
+    else {
+      osalDbgAssert(false, "invalid SPI instance");
+    }
+  }
+}
+
+#if (SPI_SELECT_MODE == SPI_SELECT_MODE_LLD) || defined(__DOXYGEN__)
+/**
+ * @brief   Asserts the slave select signal and prepares for transfers.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+void spi_lld_select(SPIDriver *spip) {
+
+  /* No implementation on AT32.*/
+}
+
+/**
+ * @brief   Deasserts the slave select signal.
+ * @details The previously selected peripheral is unselected.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+void spi_lld_unselect(SPIDriver *spip) {
+
+  /* No implementation on AT32.*/
+}
+#endif
+
+/**
+ * @brief   Ignores data on the SPI bus.
+ * @details This synchronous function performs the transmission of a series of
+ *          idle words on the SPI bus and ignores the received data.
+ * @pre     In order to use this function the option @p SPI_USE_SYNCHRONIZATION
+ *          must be enabled.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to be ignored
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_ignore(SPIDriver *spip, size_t n) {
+
+  osalDbgAssert(n <= AT32_DMA_MAX_TRANSFER, "unsupported DMA transfer size");
+
+  dmaStreamSetMemory0(spip->dmarx, &spip->rxsink);
+  dmaStreamSetTransactionSize(spip->dmarx, n);
+  dmaStreamSetMode(spip->dmarx, spip->rxdmamode);
+
+  dmaStreamSetMemory0(spip->dmatx, &spip->txsource);
+  dmaStreamSetTransactionSize(spip->dmatx, n);
+  dmaStreamSetMode(spip->dmatx, spip->txdmamode);
+
+  dmaStreamEnable(spip->dmarx);
+  dmaStreamEnable(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Exchanges data on the SPI bus.
+ * @details This asynchronous function starts a simultaneous transmit/receive
+ *          operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to be exchanged
+ * @param[in] txbuf     the pointer to the transmit buffer
+ * @param[out] rxbuf    the pointer to the receive buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_exchange(SPIDriver *spip, size_t n,
+                       const void *txbuf, void *rxbuf) {
+
+  osalDbgAssert(n <= AT32_DMA_MAX_TRANSFER, "unsupported DMA transfer size");
+
+  dmaStreamSetMemory0(spip->dmarx, rxbuf);
+  dmaStreamSetTransactionSize(spip->dmarx, n);
+  dmaStreamSetMode(spip->dmarx, spip->rxdmamode | AT32_DMA_CCTRL_MINCM);
+
+  dmaStreamSetMemory0(spip->dmatx, txbuf);
+  dmaStreamSetTransactionSize(spip->dmatx, n);
+  dmaStreamSetMode(spip->dmatx, spip->txdmamode | AT32_DMA_CCTRL_MINCM);
+
+  dmaStreamEnable(spip->dmarx);
+  dmaStreamEnable(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Sends data over the SPI bus.
+ * @details This asynchronous function starts a transmit operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to send
+ * @param[in] txbuf     the pointer to the transmit buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_send(SPIDriver *spip, size_t n, const void *txbuf) {
+
+  osalDbgAssert(n <= AT32_DMA_MAX_TRANSFER, "unsupported DMA transfer size");
+
+  dmaStreamSetMemory0(spip->dmarx, &spip->rxsink);
+  dmaStreamSetTransactionSize(spip->dmarx, n);
+  dmaStreamSetMode(spip->dmarx, spip->rxdmamode);
+
+  dmaStreamSetMemory0(spip->dmatx, txbuf);
+  dmaStreamSetTransactionSize(spip->dmatx, n);
+  dmaStreamSetMode(spip->dmatx, spip->txdmamode | AT32_DMA_CCTRL_MINCM);
+
+  dmaStreamEnable(spip->dmarx);
+  dmaStreamEnable(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Receives data from the SPI bus.
+ * @details This asynchronous function starts a receive operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to receive
+ * @param[out] rxbuf    the pointer to the receive buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_receive(SPIDriver *spip, size_t n, void *rxbuf) {
+
+  osalDbgAssert(n <= AT32_DMA_MAX_TRANSFER, "unsupported DMA transfer size");
+
+  dmaStreamSetMemory0(spip->dmarx, rxbuf);
+  dmaStreamSetTransactionSize(spip->dmarx, n);
+  dmaStreamSetMode(spip->dmarx, spip->rxdmamode | AT32_DMA_CCTRL_MINCM);
+
+  dmaStreamSetMemory0(spip->dmatx, &spip->txsource);
+  dmaStreamSetTransactionSize(spip->dmatx, n);
+  dmaStreamSetMode(spip->dmatx, spip->txdmamode);
+
+  dmaStreamEnable(spip->dmarx);
+  dmaStreamEnable(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Aborts the ongoing SPI operation, if any.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[out] sizep    pointer to the counter of frames not yet transferred
+ *                      or @p NULL
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_stop_transfer(SPIDriver *spip, size_t *sizep) {
+  msg_t msg;
+
+  /* Stopping everything.*/
+  msg = spi_lld_stop_abort(spip);
+
+  if (sizep != NULL) {
+    *sizep = dmaStreamGetTransactionSize(spip->dmarx);
+  }
+
+  return msg;
+}
+
+/**
+ * @brief   Exchanges one frame using a polled wait.
+ * @details This synchronous function exchanges one frame using a polled
+ *          synchronization method. This function is useful when exchanging
+ *          small amount of data on high speed channels, usually in this
+ *          situation is much more efficient just wait for completion using
+ *          polling than suspending the thread waiting for an interrupt.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] frame     the data frame to send over the SPI bus
+ * @return              The received data frame from the SPI bus.
+ */
+uint16_t spi_lld_polled_exchange(SPIDriver *spip, uint16_t frame) {
+
+  spip->spi->DT = frame;
+  while ((spip->spi->STS & SPI_STS_RDBF) == 0U)
+    ;
+  return spip->spi->DT;
+}
+
+#endif /* HAL_USE_SPI */
+
+/** @} */

--- a/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
+++ b/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
@@ -1,0 +1,262 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+    ChibiOS - Copyright (C) 2023 HorrorTroll
+    ChibiOS - Copyright (C) 2023 Zhaqian
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    SPIv1/hal_spi_v2_lld.h
+ * @brief   AT32 SPI (v2) subsystem low level driver header.
+ *
+ * @addtogroup SPI
+ * @{
+ */
+
+#ifndef HAL_SPI_V2_LLD_H
+#define HAL_SPI_V2_LLD_H
+
+#if HAL_USE_SPI || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Circular mode support flag.
+ */
+#define SPI_SUPPORTS_CIRCULAR           TRUE
+
+/**
+ * @brief   Slave mode support flag.
+ */
+#define SPI_SUPPORTS_SLAVE_MODE         TRUE
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   SPI1 driver enable switch.
+ * @details If set to @p TRUE the support for SPI1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AT32_SPI_USE_SPI1) || defined(__DOXYGEN__)
+#define AT32_SPI_USE_SPI1                   FALSE
+#endif
+
+/**
+ * @brief   SPI2 driver enable switch.
+ * @details If set to @p TRUE the support for SPI2 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AT32_SPI_USE_SPI2) || defined(__DOXYGEN__)
+#define AT32_SPI_USE_SPI2                   FALSE
+#endif
+
+/**
+ * @brief   Filler pattern used when there is nothing to transmit.
+ */
+#if !defined(AT32_SPI_FILLER_PATTERN) || defined(__DOXYGEN__)
+#define AT32_SPI_FILLER_PATTERN             0xFFFFFFFFU
+#endif
+
+/**
+ * @brief   SPI1 interrupt priority level setting.
+ */
+#if !defined(AT32_SPI_SPI1_IRQ_PRIORITY) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_IRQ_PRIORITY          10
+#endif
+
+/**
+ * @brief   SPI2 interrupt priority level setting.
+ */
+#if !defined(AT32_SPI_SPI2_IRQ_PRIORITY) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_IRQ_PRIORITY          10
+#endif
+
+/**
+ * @brief   SPI1 DMA priority (0..3|lowest..highest).
+ * @note    The priority level is used for both the TX and RX DMA streams but
+ *          because of the streams ordering the RX stream has always priority
+ *          over the TX stream.
+ */
+#if !defined(AT32_SPI_SPI1_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_DMA_PRIORITY          1
+#endif
+
+/**
+ * @brief   SPI2 DMA priority (0..3|lowest..highest).
+ * @note    The priority level is used for both the TX and RX DMA streams but
+ *          because of the streams ordering the RX stream has always priority
+ *          over the TX stream.
+ */
+#if !defined(AT32_SPI_SPI2_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_DMA_PRIORITY          1
+#endif
+
+/**
+ * @brief   SPI DMA error hook.
+ */
+#if !defined(AT32_SPI_DMA_ERROR_HOOK) || defined(__DOXYGEN__)
+#define AT32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if AT32_SPI_USE_SPI1 && !AT32_HAS_SPI1
+#error "SPI1 not present in the selected device"
+#endif
+
+#if AT32_SPI_USE_SPI2 && !AT32_HAS_SPI2
+#error "SPI2 not present in the selected device"
+#endif
+
+#if !AT32_SPI_USE_SPI1 && !AT32_SPI_USE_SPI2
+#error "SPI driver activated but no SPI peripheral assigned"
+#endif
+
+#if AT32_SPI_USE_SPI1 &&                                                    \
+    !OSAL_IRQ_IS_VALID_PRIORITY(AT32_SPI_SPI1_IRQ_PRIORITY)
+#error "Invalid IRQ priority assigned to SPI1"
+#endif
+
+#if AT32_SPI_USE_SPI2 &&                                                    \
+    !OSAL_IRQ_IS_VALID_PRIORITY(AT32_SPI_SPI2_IRQ_PRIORITY)
+#error "Invalid IRQ priority assigned to SPI2"
+#endif
+
+/* The following checks are only required when there is a DMA able to
+   reassign streams to different channels.*/
+#if AT32_ADVANCED_DMA
+/* Check on the presence of the DMA streams settings in mcuconf.h.*/
+#if AT32_SPI_USE_SPI1 && (!defined(AT32_SPI_SPI1_RX_DMA_STREAM) ||          \
+                          !defined(AT32_SPI_SPI1_TX_DMA_STREAM))
+#error "SPI1 DMA streams not defined"
+#endif
+
+#if AT32_SPI_USE_SPI2 && (!defined(AT32_SPI_SPI2_RX_DMA_STREAM) ||          \
+                          !defined(AT32_SPI_SPI2_TX_DMA_STREAM))
+#error "SPI2 DMA streams not defined"
+#endif
+
+/* Check on the validity of the assigned DMA channels.*/
+#if AT32_SPI_USE_SPI1 &&                                                    \
+    !AT32_DMA_IS_VALID_ID(AT32_SPI_SPI1_RX_DMA_STREAM, AT32_SPI1_RX_DMA_MSK)
+#error "invalid DMA stream associated to SPI1 RX"
+#endif
+
+#if AT32_SPI_USE_SPI1 &&                                                    \
+    !AT32_DMA_IS_VALID_ID(AT32_SPI_SPI1_TX_DMA_STREAM, AT32_SPI1_TX_DMA_MSK)
+#error "invalid DMA stream associated to SPI1 TX"
+#endif
+
+#if AT32_SPI_USE_SPI2 &&                                                    \
+    !AT32_DMA_IS_VALID_ID(AT32_SPI_SPI2_RX_DMA_STREAM, AT32_SPI2_RX_DMA_MSK)
+#error "invalid DMA stream associated to SPI2 RX"
+#endif
+
+#if AT32_SPI_USE_SPI2 &&                                                    \
+    !AT32_DMA_IS_VALID_ID(AT32_SPI_SPI2_TX_DMA_STREAM, AT32_SPI2_TX_DMA_MSK)
+#error "invalid DMA stream associated to SPI2 TX"
+#endif
+#endif /* AT32_ADVANCED_DMA */
+
+#if !defined(AT32_DMA_REQUIRED)
+#define AT32_DMA_REQUIRED
+#endif
+
+#if SPI_SELECT_MODE == SPI_SELECT_MODE_LLD
+#error "SPI_SELECT_MODE_LLD not supported by this driver"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#define spi_lld_driver_fields                                               \
+  /* Pointer to the SPIx registers block.*/                                 \
+  SPI_TypeDef               *spi;                                           \
+  /* Receive DMA stream.*/                                                  \
+  const at32_dma_stream_t   *dmarx;                                         \
+  /* Transmit DMA stream.*/                                                 \
+  const at32_dma_stream_t   *dmatx;                                         \
+  /* RX DMA mode bit mask.*/                                                \
+  uint32_t                  rxdmamode;                                      \
+  /* TX DMA mode bit mask.*/                                                \
+  uint32_t                  txdmamode;                                      \
+  /* Sink for discarded data.*/                                             \
+  uint32_t                  rxsink;                                         \
+  /* Source for default TX pattern.*/                                       \
+  uint32_t                  txsource
+
+/**
+ * @brief   Low level fields of the SPI configuration structure.
+ */
+#define spi_lld_config_fields                                               \
+  /* SPI CTRL1 register initialization data.*/                              \
+  uint16_t                  ctrl1;                                          \
+  /* SPI CTRL2 register initialization data.*/                              \
+  uint16_t                  ctrl2
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if AT32_SPI_USE_SPI1 && !defined(__DOXYGEN__)
+extern SPIDriver SPID1;
+#endif
+
+#if AT32_SPI_USE_SPI2 && !defined(__DOXYGEN__)
+extern SPIDriver SPID2;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void spi_lld_init(void);
+  msg_t spi_lld_start(SPIDriver *spip);
+  void spi_lld_stop(SPIDriver *spip);
+#if (SPI_SELECT_MODE == SPI_SELECT_MODE_LLD) || defined(__DOXYGEN__)
+  void spi_lld_select(SPIDriver *spip);
+  void spi_lld_unselect(SPIDriver *spip);
+#endif
+  msg_t spi_lld_ignore(SPIDriver *spip, size_t n);
+  msg_t spi_lld_exchange(SPIDriver *spip, size_t n,
+                         const void *txbuf, void *rxbuf);
+  msg_t spi_lld_send(SPIDriver *spip, size_t n, const void *txbuf);
+  msg_t spi_lld_receive(SPIDriver *spip, size_t n, void *rxbuf);
+  msg_t spi_lld_stop_transfer(SPIDriver *spip, size_t *sizep);
+  uint16_t spi_lld_polled_exchange(SPIDriver *spip, uint16_t frame);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_SPI */
+
+#endif /* HAL_SPI_V2_LLD_H */
+
+/** @} */

--- a/os/hal/ports/AT32/LLD/SYSTICKv1/hal_st_lld.c
+++ b/os/hal/ports/AT32/LLD/SYSTICKv1/hal_st_lld.c
@@ -40,8 +40,10 @@
 
 #if (OSAL_ST_RESOLUTION == 32)
 #define ST_PR_INIT                          0xFFFFFFFFU
+#define ST_CTRL1_INIT                       0x00000400U
 #else
 #define ST_PR_INIT                          0x0000FFFFU
+#define ST_CTRL1_INIT                       0x00000000U
 #endif
 
 #if AT32_ST_USE_TIMER == 2
@@ -253,6 +255,7 @@ void st_lld_init(void) {
   ST_ENABLE_PAUSE();
 
   /* Initializing the counter in free running mode.*/
+  AT32_ST_TMR->CTRL1  = ST_CTRL1_INIT;
   AT32_ST_TMR->DIV    = (ST_CLOCK_SRC / OSAL_ST_FREQUENCY) - 1;
   AT32_ST_TMR->PR     = ST_PR_INIT;
   AT32_ST_TMR->CM1    = 0;
@@ -269,7 +272,7 @@ void st_lld_init(void) {
   AT32_ST_TMR->IDEN   = 0;
   AT32_ST_TMR->CTRL2  = 0;
   AT32_ST_TMR->SWEVT  = AT32_TMR_SWEVT_OVFSWTR;
-  AT32_ST_TMR->CTRL1  = AT32_TMR_CTRL1_TMREN;
+  AT32_ST_TMR->CTRL1 |= AT32_TMR_CTRL1_TMREN;
 
 #if !defined(AT32_SYSTICK_SUPPRESS_ISR)
   /* IRQ enabled.*/


### PR DESCRIPTION
Added support SPI v1 HAL driver, it does init and running on QMK. But something wrong that `SCK / MOSI / MISO lines` doesn't sending signal if key matrix is not pressing. If you have some free time for reviewing, can you try out and debug it?

Setup I was try testing is using QMK Quantum Painter with LCD ST7735 (160x80) module.

Video showcase of testing and issues:

https://github.com/qmk-arterytek/ChibiOS-Contrib/assets/24840279/5678cfd5-0bff-4075-ae23-2e75fb43f66c


