### PR TITLE
Clean up and init flexible DMA

### DIFF
--- a/os/hal/ports/AT32/AT32F41x/at32_registry.h
+++ b/os/hal/ports/AT32/AT32F41x/at32_registry.h
@@ -66,7 +66,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -125,12 +130,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -139,20 +156,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -191,22 +225,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     FALSE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1
@@ -234,7 +296,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -293,12 +360,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -307,20 +386,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -359,22 +455,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     FALSE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1
@@ -402,7 +526,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -461,12 +590,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -475,20 +616,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -527,22 +685,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     FALSE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1
@@ -570,7 +756,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -629,12 +820,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -643,20 +846,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -695,22 +915,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     FALSE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1
@@ -738,7 +986,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -797,12 +1050,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -811,20 +1076,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -863,22 +1145,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     TRUE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1
@@ -906,7 +1216,12 @@
 #define AT32_CAN_MAX_FILTERS               14
 
 /* DMA attributes.*/
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
 #define AT32_DMA_SUPPORTS_DMAMUX           TRUE
+#else
+#define AT32_DMA_SUPPORTS_DMAMUX           FALSE
+#endif
+
 #define AT32_DMA1_NUM_CHANNELS             7
 #define AT32_DMA1_CH1_HANDLER              Vector6C
 #define AT32_DMA1_CH2_HANDLER              Vector70
@@ -965,12 +1280,24 @@
 
 /* I2C attributes.*/
 #define AT32_HAS_I2C1                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 7)
 #define AT32_I2C_I2C1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 6)
+#endif
 
 #define AT32_HAS_I2C2                      TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_I2C_I2C2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
 #define AT32_I2C_I2C2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 /* RTC attributes.*/
 #define AT32_HAS_RTC                       TRUE
@@ -979,20 +1306,37 @@
 
 /* SDIO attributes.*/
 #define AT32_HAS_SDIO1                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SDC_SDIO1_DMA_STREAM          AT32_DMA_STREAM_ID(2, 4)
+#endif
 
 /* SPI attributes.*/
 #define AT32_HAS_SPI1                      TRUE
 #define AT32_SPI1_SUPPORTS_I2S             TRUE
 #define AT32_SPI1_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI1_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 2)
 #define AT32_SPI_SPI1_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 3)
+#endif
 
 #define AT32_HAS_SPI2                      TRUE
 #define AT32_SPI2_SUPPORTS_I2S             TRUE
 #define AT32_SPI2_I2S_FULLDUPLEX           FALSE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_SPI_SPI2_RX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 4)
 #define AT32_SPI_SPI2_TX_DMA_STREAM        AT32_DMA_STREAM_ID(1, 5)
+#endif
 
 /* TMR attributes.*/
 #define AT32_TMR_MAX_CHANNELS              4
@@ -1031,22 +1375,50 @@
 
 /* USART attributes.*/
 #define AT32_HAS_USART1                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART1_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 5)
 #define AT32_UART_USART1_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 4)
+#endif
 
 #define AT32_HAS_USART2                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART2_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 6)
 #define AT32_UART_USART2_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 7)
+#endif
 
 #define AT32_HAS_USART3                    TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_USART3_RX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 3)
 #define AT32_UART_USART3_TX_DMA_STREAM     AT32_DMA_STREAM_ID(1, 2)
+#endif
 
 #define AT32_HAS_UART4                     TRUE
+
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#else
 #define AT32_UART_UART4_RX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 3)
 #define AT32_UART_UART4_TX_DMA_STREAM      AT32_DMA_STREAM_ID(2, 5)
+#endif
 
 #define AT32_HAS_UART5                     TRUE
+#if AT32_DMA_USE_DMAMUX || defined(__DOXYGEN__)
+#define AT32_UART_UART5_RX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#define AT32_UART_UART5_TX_DMA_STREAM      AT32_DMA_STREAM_ID_ANY
+#endif
 
 /* USB attributes.*/
 #define AT32_OTG_STEPPING                  1

--- a/os/hal/ports/AT32/LLD/DMAv1/at32_dma.c
+++ b/os/hal/ports/AT32/LLD/DMAv1/at32_dma.c
@@ -21,6 +21,13 @@
  * @brief   DMA helper driver code.
  *
  * @addtogroup AT32_DMA
+ * @details DMA sharing helper driver. In the AT32 the DMA streams are a
+ *          shared resource, this driver allows to allocate and free DMA
+ *          streams at runtime in order to allow all the other device
+ *          drivers to coordinate the access to the resource.
+ * @note    The DMA STS handlers are all declared into this module because
+ *          sharing, the various device drivers can associate a callback to
+ *          STSs when allocating streams.
  * @{
  */
 
@@ -37,12 +44,12 @@
 /**
  * @brief   Mask of the DMA1 streams in @p dma_streams_mask.
  */
-#define AT32_DMA1_STREAMS_MASK     ((1U << AT32_DMA1_NUM_CHANNELS) - 1U)
+#define AT32_DMA1_STREAMS_MASK      ((1U << AT32_DMA1_NUM_CHANNELS) - 1U)
 
 /**
  * @brief   Mask of the DMA2 streams in @p dma_streams_mask.
  */
-#define AT32_DMA2_STREAMS_MASK     (((1U << AT32_DMA2_NUM_CHANNELS) -     \
+#define AT32_DMA2_STREAMS_MASK      (((1U << AT32_DMA2_NUM_CHANNELS) -      \
                                       1U) << AT32_DMA1_NUM_CHANNELS)
 
 #define DMA1_CH1_VARIANT            0
@@ -537,13 +544,6 @@ const at32_dma_stream_t *dmaStreamAllocI(uint32_t id,
       }
 #endif
 
-#if (AT32_DMA_SUPPORTS_DMAMUX == TRUE) && defined(crmEnableDMAMUX)
-      /* Enabling DMAMUX if present.*/
-      if (dma.allocated_mask != 0U) {
-        crmEnableDMAMUX(true);
-      }
-#endif
-
       /* Enables the associated IRQ vector if not already enabled and if a
          callback is defined.*/
       if (func != NULL) {
@@ -638,13 +638,6 @@ void dmaStreamFreeI(const at32_dma_stream_t *dmastp) {
 #if AT32_DMA2_NUM_CHANNELS > 0
   if ((dma.allocated_mask & AT32_DMA2_STREAMS_MASK) == 0U) {
     crmDisableDMA2();
-  }
-#endif
-
-#if (AT32_DMA_SUPPORTS_DMAMUX == TRUE) && defined(crmDisableDMAMUX)
-  /* Shutting down DMAMUX if present.*/
-  if (dma.allocated_mask == 0U) {
-    crmDisableDMAMUX();
   }
 #endif
 }

--- a/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
+++ b/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.c
@@ -300,6 +300,10 @@ msg_t spi_lld_start(SPIDriver *spip) {
       }
       crmEnableSPI1(true);
       crmResetSPI1();
+#if AT32_DMA_SUPPORTS_DMAMUX && AT32_DMA_USE_DMAMUX
+      dmaSetRequestSource(spip->dmarx, AT32_SPI_SPI1_RX_DMAMUX_CHANNEL, AT32_DMAMUX_SPI1_RX);
+      dmaSetRequestSource(spip->dmatx, AT32_SPI_SPI1_TX_DMAMUX_CHANNEL, AT32_DMAMUX_SPI1_TX);
+#endif
     }
 #endif
 
@@ -314,6 +318,10 @@ msg_t spi_lld_start(SPIDriver *spip) {
       }
       crmEnableSPI2(true);
       crmResetSPI2();
+#if AT32_DMA_SUPPORTS_DMAMUX && AT32_DMA_USE_DMAMUX
+      dmaSetRequestSource(spip->dmarx, AT32_SPI_SPI2_RX_DMAMUX_CHANNEL, AT32_DMAMUX_SPI2_RX);
+      dmaSetRequestSource(spip->dmatx, AT32_SPI_SPI2_TX_DMAMUX_CHANNEL, AT32_DMAMUX_SPI2_TX);
+#endif
     }
 #endif
 

--- a/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
+++ b/os/hal/ports/AT32/LLD/SPIv1/hal_spi_v2_lld.h
@@ -117,6 +117,28 @@
 #if !defined(AT32_SPI_DMA_ERROR_HOOK) || defined(__DOXYGEN__)
 #define AT32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
 #endif
+
+#if AT32_DMA_SUPPORTS_DMAMUX && AT32_DMA_USE_DMAMUX
+
+/**
+ * @brief   SPI1 DMA MUX setting.
+ */
+#if !defined(AT32_SPI_SPI1_RX_DMAMUX_CHANNEL) || \
+    !defined(AT32_SPI_SPI1_TX_DMAMUX_CHANNEL) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI1_RX_DMAMUX_CHANNEL     0
+#define AT32_SPI_SPI1_TX_DMAMUX_CHANNEL     0
+#endif
+
+/**
+ * @brief   SPI2 DMA MUX setting.
+ */
+#if !defined(AT32_SPI_SPI2_RX_DMAMUX_CHANNEL) || \
+    !defined(AT32_SPI_SPI2_TX_DMAMUX_CHANNEL) || defined(__DOXYGEN__)
+#define AT32_SPI_SPI2_RX_DMAMUX_CHANNEL     0
+#define AT32_SPI_SPI2_TX_DMAMUX_CHANNEL     0
+#endif
+
+#endif
 /** @} */
 
 /*===========================================================================*/


### PR DESCRIPTION
I'm just clean up some leftover, and try to init flexible DMA. Testing on SPI and it did work with channel 1/2/3/4, but 5/6/7 causing the board not init.

Probably missing something? Can you take a look and try it out?

Reopen new pr: #13 